### PR TITLE
Fix spelling that shows up in the User Settings dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "contributes": {
         "configuration": {
             "type": "object",
-            "title": "Suble Brackets",
+            "title": "Subtle Brackets",
             "properties": {
                 "subtleBrackets.parse": {
                     "type": "boolean",


### PR DESCRIPTION
Changing `Suble` to `Subtle`:

<img src="https://user-images.githubusercontent.com/5829188/38473252-dd59ff26-3b41-11e8-9959-569c53742890.png" width="300px">